### PR TITLE
Make autoload work if plugin is installed in a different plugins directory

### DIFF
--- a/SentryLogger.php
+++ b/SentryLogger.php
@@ -27,7 +27,7 @@ class SentryLogger extends \Piwik\Plugin
 
         if ($dsn) {
             // Add composer dependencies
-            require_once PIWIK_INCLUDE_PATH . '/plugins/SentryLogger/vendor/autoload.php';
+            require_once __DIR__ . '/vendor/autoload.php';
 
             \Sentry\init([
                 'dsn' => $dsn,


### PR DESCRIPTION

This way it would eg work in Matomo for WordPress but also if a custom plugins directory is defined.